### PR TITLE
chore: Update badge messages and release notes to reflect stable vers…

### DIFF
--- a/_data/badges.yml
+++ b/_data/badges.yml
@@ -2,7 +2,7 @@
 
 release_notes:
       label: "Release Notes"
-      message: "v1.0.0-Alpha"      # The actual text to display on the badge
+      message: "v1.0.0"      # The actual text to display on the badge
       color: "blue"
       style: "plastic"
       logo: "github"
@@ -11,7 +11,7 @@ release_notes:
 
 zeta_api:
       label: "ZETA API"
-      message: "v1.0.0-Alpha"
+      message: "v1.0.0"
       color: "green"
       style: "plastic"
       logo: "github"
@@ -20,7 +20,7 @@ zeta_api:
 
 zeta_guard:
       label: "ZETA Guard"
-      message: "v1.0.0-Alpha"
+      message: "v1.0.0"
       color: "orange"
       style: "plastic"
       logo: "github"

--- a/release-notes.md
+++ b/release-notes.md
@@ -8,14 +8,26 @@ parent: ZETA
 
 Die Release Notes bieten einen Überblick über die Änderungen und Neuerungen in der ZETA API.
 
-### v1.0.0-Alpha
+### v1.0.0
 
-Erste Alpha-Version der ZETA API veröffentlicht.
+#### What's Changed
+
+* Feature/qs by @gem-cp in https://github.com/gematik/ZETA/pull/1
+* Develop by @gem-cp in https://github.com/gematik/ZETA/pull/2
+* Develop by @gem-cp in https://github.com/gematik/ZETA/pull/3
+* fix: Update Jekyll configuration for GitHub Pages and comment out unu… by @gem-cp in https://github.com/gematik/ZETA/pull/4
+* fix: Remove optional logo and favicon configuration from Jekyll config by @gem-cp in https://github.com/gematik/ZETA/pull/5
+* fix: Update README and API documentation structure for clarity and co… by @gem-cp in https://github.com/gematik/ZETA/pull/6
+* update: remove v2 index page by @gem-cp in https://github.com/gematik/ZETA/pull/7
+* fix: Update ZETA API documentation link to point to the correct index… by @gem-cp in https://github.com/gematik/ZETA/pull/8
+* fix: Clean up Jekyll configuration by removing commented-out code and… by @gem-cp in https://github.com/gematik/ZETA/pull/9
+
+**Full Changelog**: https://github.com/gematik/ZETA/commits/v1.0.0
 
 ## ZETA Guard
 
 Die Release Notes bieten einen Überblick über die Änderungen und Neuerungen im ZETA Guard.
 
-### v1.0.0-Alpha
+### v1.0.0
 
-Erste Alpha-Version des ZETA Guards veröffentlicht.
+Erste Version des ZETA Guards veröffentlicht.


### PR DESCRIPTION
This pull request updates the versioning across multiple files to reflect the transition from "v1.0.0-Alpha" to "v1.0.0" and enhances the release notes with detailed changelog entries for better clarity and documentation.

### Version updates:
* [`_data/badges.yml`](diffhunk://#diff-75fa8d27448f4adc348e20867c0e9f3d4174c67ff82f2250f262f68f342905f7L5-R5): Updated the `message` field for `release_notes`, `zeta_api`, and `zeta_guard` badges to reflect the version change from "v1.0.0-Alpha" to "v1.0.0". [[1]](diffhunk://#diff-75fa8d27448f4adc348e20867c0e9f3d4174c67ff82f2250f262f68f342905f7L5-R5) [[2]](diffhunk://#diff-75fa8d27448f4adc348e20867c0e9f3d4174c67ff82f2250f262f68f342905f7L14-R14) [[3]](diffhunk://#diff-75fa8d27448f4adc348e20867c0e9f3d4174c67ff82f2250f262f68f342905f7L23-R23)

### Release notes enhancements:
* [`release-notes.md`](diffhunk://#diff-82200ce47fa528129da57d8979b63119ebdc262e3d07cb7882fdb8d1ecdf4a00L11-R33): Updated the section headers from "v1.0.0-Alpha" to "v1.0.0" and added a detailed list of changes under "What's Changed," including links to pull requests and a full changelog URL for better traceability.