### PR TITLE
fix: update access token schema with corrected JWT enum casing and va…

### DIFF
--- a/src/schemas/access-token.yaml
+++ b/src/schemas/access-token.yaml
@@ -14,7 +14,7 @@ properties:
         description: Type of the JWT. Must be "at+jwt" or "jwt".
         enum:
           - at+jwt
-          - jwt
+          - JWT
       alg:
         type: string
         description: Asymmetric algorithm used to sign the JWT.
@@ -81,7 +81,7 @@ properties:
         type: integer
         description: Issued at time of the token as a Unix timestamp.
       jti:
-        type: stringextended
+        type: string
         description: The JWT ID.
       scope:
         type: string


### PR DESCRIPTION
This pull request makes minor corrections to the `src/schemas/access-token.yaml` schema, ensuring consistency and accuracy in the JWT properties.

* Changed the allowed value for the `typ` property from lowercase `"jwt"` to uppercase `"JWT"` to match expected standards.
* Fixed the type of the `jti` property from an incorrect `stringextended` to the correct `string` type.…lid string type for jti