### PR TITLE
docs: clarify store_id usage for Windows app schema

### DIFF
--- a/src/schemas/product-id-windows.yaml
+++ b/src/schemas/product-id-windows.yaml
@@ -9,7 +9,7 @@ properties:
     const: "windows"
   store_id:
     type: string
-    description: The Store ID for the Windows app.
+    description: The Store ID for the Windows app. This can be the official Microsoft Store ID or an identifier from a custom/private store. If the app is not distributed via a store, this claim should be left empty or omitted.
   package_family_name:
     type: string
     description: The Package Family Name for the Windows app.


### PR DESCRIPTION
This pull request updates the documentation for the `store_id` property in the `product-id-windows.yaml` schema. The main change clarifies how the `store_id` should be used for Windows apps.

Documentation improvements:

* Expanded the description for the `store_id` property to specify that it can be the official Microsoft Store ID, an identifier from a custom/private store, or omitted if the app is not distributed via a store.