### PR TITLE
Develop

### DIFF
--- a/src/schemas/product-id-windows.yaml
+++ b/src/schemas/product-id-windows.yaml
@@ -9,7 +9,7 @@ properties:
     const: "windows"
   store_id:
     type: string
-    description: The Store ID for the Windows app.
+    description: The Store ID for the Windows app. This can be the official Microsoft Store ID or an identifier from a custom/private store. If the app is not distributed via a store, this claim should be left empty or omitted.
   package_family_name:
     type: string
     description: The Package Family Name for the Windows app.


### PR DESCRIPTION
This pull request updates the description for the `store_id` property in the `product-id-windows.yaml` schema to provide clearer guidance on its usage, especially regarding apps not distributed via a store.

- Schema documentation improvement:
  * Clarified the `store_id` property description to specify that it can be either an official Microsoft Store ID or a custom/private store identifier, and that it should be left empty or omitted if the app is not distributed via a store.