### PR TITLE
Develop

### DIFF
--- a/src/schemas/access-token.yaml
+++ b/src/schemas/access-token.yaml
@@ -11,7 +11,7 @@ properties:
     properties:
       typ:
         type: string
-        description: Type of the JWT. Must be "at+jwt" or "jwt".
+        description: Type of the JWT. Must be "at+jwt" or "JWT".
         enum:
           - at+jwt
           - JWT

--- a/src/schemas/client-assertion-jwt.yaml
+++ b/src/schemas/client-assertion-jwt.yaml
@@ -9,9 +9,9 @@ properties:
     properties:
       typ:
         type: string
-        description: Type of the JWT, which MUST be 'jwt'.
+        description: Type of the JWT, which MUST be 'JWT'.
         enum:
-          - jwt
+          - JWT
       alg:
         type: string
         description: Algorithm used to sign the JWT, which MUST be 'ES256'.
@@ -39,7 +39,7 @@ properties:
             type: string
             format: byte
             description: Y coordinate of the EC public key (Base64URL).
-        required: 
+        required:
           - kty
           - crv
           - x
@@ -62,7 +62,7 @@ properties:
         items:
           type: string
           description: Audience for the JWT. It MUST contain the
-                       Authorization Server's token endpoint URL.
+            Authorization Server's token endpoint URL.
         minItems: 1
       exp:
         type: integer
@@ -81,4 +81,3 @@ properties:
       - aud
       - exp
       - jti
-


### PR DESCRIPTION
This pull request updates the JWT type descriptions and allowed values in the OpenAPI schema YAML files to ensure consistency and compliance with standards. The most important changes are:

**JWT Type Standardization:**

* Updated the `typ` property in `src/schemas/access-token.yaml` to require "at+jwt" or "JWT" (uppercase), both in the description and enum values.
* Updated the `typ` property in `src/schemas/client-assertion-jwt.yaml` to require "JWT" (uppercase), both in the description and enum values.

**Minor formatting:**

* Removed an unnecessary blank line at the end of the required properties list in `src/schemas/client-assertion-jwt.yaml`.