### PR TITLE
docs: update API version to v1.3.1 in index.md

### DIFF
--- a/docs/api/v1/index.md
+++ b/docs/api/v1/index.md
@@ -1,11 +1,11 @@
-# ZETA API v1.3.0
+# ZETA API v1.3.1
 
 ## Dokumenten- und Versionsübersicht
 
 |                             |                             |
 |-----------------------------|-----------------------------|
-| Dokumenttitel               | ZETA API v1.3.0             |
-| Dokumentversion             | 1.3.0                       |
+| Dokumenttitel               | ZETA API v1.3.1             |
+| Dokumentversion             | 1.3.1                       |
 | Stand                       | 01.06.2026                  |
 | Status                      | Draft                       |
 | Verantwortlich              | gematik                     |


### PR DESCRIPTION
This pull request updates the documentation for the ZETA API to reflect the new version 1.3.1.

Documentation updates:

* Updated the API version and document title in `docs/api/v1/index.md` from 1.3.0 to 1.3.1.