### PR TITLE
merge develop <-- main

### DIFF
--- a/.cspell/zeta-words.txt
+++ b/.cspell/zeta-words.txt
@@ -79,6 +79,7 @@ Multitenancy
 Subresource
 
 # --- TI und ZETA spezifische Begriffe ---
+ANFTI
 Autorisierungsregeln
 europe
 Hauptrepository
@@ -87,6 +88,8 @@ jwks
 Komponentendokumentation
 Konnektor
 Konnektors
+kubeconform
+kubeval
 Leistungserbringerinstitutionen
 nginx
 popp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,21 +7,22 @@ Dieses Dokument beschreibt, wie du Änderungen vorschlagen und Pull Requests ein
 
 ## Inhaltsverzeichnis
 
-- [Inhaltsverzeichnis](#inhaltsverzeichnis)
-- [Verhaltenskodex](#verhaltenskodex)
-- [Fehler melden und Feature-Anfragen](#fehler-melden-und-feature-anfragen)
-- [Jira-Pflicht für Pull Requests](#jira-pflicht-für-pull-requests)
-  - [Warum?](#warum)
-  - [So geht's](#so-gehts)
-  - [Namenskonvention](#namenskonvention)
-  - [Beispiel](#beispiel)
-- [Pull Requests einreichen](#pull-requests-einreichen)
-  - [PR-Checkliste](#pr-checkliste)
-- [Branch-Konventionen](#branch-konventionen)
-- [Commit-Konventionen](#commit-konventionen)
-- [Code-Qualität](#code-qualität)
-- [Sicherheitslücken melden](#sicherheitslücken-melden)
-- [Lizenz](#lizenz)
+- [Contributing to ZETA](#contributing-to-zeta)
+  - [Inhaltsverzeichnis](#inhaltsverzeichnis)
+  - [Verhaltenskodex](#verhaltenskodex)
+  - [Fehler melden und Feature-Anfragen](#fehler-melden-und-feature-anfragen)
+  - [Jira-Pflicht für Pull Requests](#jira-pflicht-für-pull-requests)
+    - [Warum?](#warum)
+    - [So geht's](#so-gehts)
+    - [Namenskonvention](#namenskonvention)
+    - [Beispiel](#beispiel)
+  - [Pull Requests einreichen](#pull-requests-einreichen)
+    - [PR-Checkliste](#pr-checkliste)
+  - [Branch-Konventionen](#branch-konventionen)
+  - [Commit-Konventionen](#commit-konventionen)
+  - [Code-Qualität](#code-qualität)
+  - [Sicherheitslücken melden](#sicherheitslücken-melden)
+  - [Lizenz](#lizenz)
 
 ---
 
@@ -63,7 +64,7 @@ Die interne Nachverfolgung, Planung und Priorisierung aller Arbeiten am ZETA-Pro
 
 ### Beispiel
 
-```
+``` yaml
 Titel:       [ANFTI2-456] PEP: Authentifizierungs-Header wird bei Redirect nicht weitergeleitet
 Beschreibung:
   Jira: https://jira.gematik.de/browse/ANFTI2-456
@@ -73,8 +74,6 @@ Beschreibung:
 ```
 
 PRs **ohne gültige ANFTI2-Ticket-Referenz** werden kommentiert und bis zur Nachlieferung der Referenz nicht weiterbearbeitet.
-
-
 
 ## Pull Requests einreichen
 
@@ -106,7 +105,7 @@ Bevor du deinen PR einreichst, vergewissere dich:
 
 Branches sollen nach folgendem Muster benannt werden:
 
-```
+``` yaml
 <typ>/ANFTI2-<ticket-nr>-<kurze-beschreibung-mit-bindestrichen>
 ```
 
@@ -129,7 +128,7 @@ Beispiel: `feature/ANFTI2-123-pep-header-forwarding`
 
 Wir orientieren uns an [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+``` yaml
 <typ>(optionaler-scope): ANFTI2-<nr> kurze Beschreibung
 
 Optionaler längerer Erläuterungstext.
@@ -137,7 +136,7 @@ Optionaler längerer Erläuterungstext.
 
 Beispiele:
 
-```
+``` yaml
 feat(pep): ANFTI2-123 add mTLS header forwarding on redirect
 fix(pdp): ANFTI2-456 correct OPA policy evaluation for empty claims
 docs: ANFTI2-789 update deployment guide for GKE

--- a/docs/user-manual/Anleitungen/ZETA_Guard_Quickstart.md
+++ b/docs/user-manual/Anleitungen/ZETA_Guard_Quickstart.md
@@ -209,7 +209,7 @@ namespace = "zeta-demo"      # Namespace, in dem Zeta-Guard deployt wurde
 
 Im lokalen Modus wird diese Datei nicht benötigt (sie wird leer generiert).
 
-##### Die PDP-Konfiguration wird über eine stage-spezifische Datei gesteuert:
+##### Die PDP-Konfiguration wird über eine stage-spezifische Datei gesteuert
 
 ```hcl
 insecure_tls = true                          # Aktivieren bei selbst signierten Zertifikaten (optional, Default ist false)
@@ -316,12 +316,12 @@ der [values-demo.yaml](https://github.com/gematik/zeta-guard-helm/blob/main/char
 die folgenden Direktiven
 auf die Konfiguration des PDP abzustimmen:
 
-* `pep_issuer`
+- `pep_issuer`
 
   Die Realm URL des PDP. Sollte z.B. wie folgt aussehen:
   `https://public-name-of-keycloak-here/auth/realms/zeta-guard`
 
-* `proxy_pass`
+- `proxy_pass`
 
   Das abzusichernde Ziel.
   In

--- a/scripts/check-markdown.sh
+++ b/scripts/check-markdown.sh
@@ -62,11 +62,11 @@ EXIT_CODE=0
 # 1) Link-Check
 # ---------------------------------------------------------------------------
 if command -v lychee >/dev/null 2>&1; then
-  log "Link-Check mit lychee ..."
+  log "Link-Check ..."
   LYCHEE_CONFIG="${SCRIPT_DIR}/lychee.toml"
-  LYCHEE_ARGS=()
+  LYCHEE_ARGS=(--no-progress)
   [[ -f "$LYCHEE_CONFIG" ]] && LYCHEE_ARGS+=(--config "$LYCHEE_CONFIG")
-  if lychee "${LYCHEE_ARGS[@]}" "${TARGETS[@]}"; then
+  if lychee "${LYCHEE_ARGS[@]}" "${TARGETS[@]}" >/dev/null 2> >(grep -E '^\s*\[(ERROR|WARN)\]|Error:' >&2); then
     ok "Alle Links erreichbar."
   else
     err "Defekte Links gefunden."
@@ -88,7 +88,7 @@ fi
 # ---------------------------------------------------------------------------
 # 2) Referenzierte Bilder & relative Pfade prüfen
 # ---------------------------------------------------------------------------
-log "Prüfe referenzierte lokale Dateien (Bilder, Includes) ..."
+log "Prüfe lokale Referenzen ..."
 LOCAL_FAIL=0
 for f in "${TARGETS[@]}"; do
   dir=$(dirname "$f")
@@ -118,29 +118,33 @@ fi
 # ---------------------------------------------------------------------------
 if command -v markdownlint-cli2 >/dev/null 2>&1; then
   log "Markdown-Lint ..."
-  if markdownlint-cli2 "${TARGETS[@]}"; then
+  LINT_OUT=$(markdownlint-cli2 "${TARGETS[@]}" 2>&1) || LINT_RC=$?
+  if [[ ${LINT_RC:-0} -eq 0 ]]; then
     ok "Lint OK."
   else
-    err "Lint-Verstöße gefunden."
+    err "Lint-Verstöße gefunden:"
+    echo "$LINT_OUT" | grep -E ':[0-9]+(:[0-9]+)?\s+(MD[0-9]+|error)' || echo "$LINT_OUT"
     EXIT_CODE=1
   fi
 else
-  warn "markdownlint-cli2 nicht installiert – Lint übersprungen (npm i -g markdownlint-cli2)."
+  warn "markdownlint-cli2 nicht installiert – Lint übersprungen."
 fi
 
 # ---------------------------------------------------------------------------
 # 4) Rechtschreibung
 # ---------------------------------------------------------------------------
 if command -v cspell >/dev/null 2>&1; then
-  log "Rechtschreibprüfung mit cspell ..."
-  if cspell --no-progress --config "$CSPELL_CONFIG" "${TARGETS[@]}"; then
+  log "Rechtschreibprüfung ..."
+  CSPELL_OUT=$(cspell --no-progress --no-summary --quiet --config "$CSPELL_CONFIG" "${TARGETS[@]}" 2>&1 \
+                | grep -v 'Unsupported NodeJS version' || true)
+  if [[ -z "$CSPELL_OUT" ]]; then
     ok "Keine Rechtschreibfehler."
   else
-    warn "Mögliche Rechtschreibfehler gefunden."
-    # Rechtschreibung nur als Warnung, kein Exit-Fehler
+    warn "Mögliche Rechtschreibfehler:"
+    echo "$CSPELL_OUT"
   fi
 else
-  warn "cspell nicht installiert – Rechtschreibprüfung übersprungen (npm i -g cspell @cspell/dict-de-de)."
+  warn "cspell nicht installiert – Rechtschreibprüfung übersprungen."
 fi
 
 echo

--- a/scripts/lychee.toml
+++ b/scripts/lychee.toml
@@ -43,8 +43,5 @@ exclude = [
   '^mailto:',
 ]
 
-# Anker (Fragment) prüfen, wenn lokale Datei existiert
-include_fragments = true
-
-# Verbose-Logging-Level
-verbose = "info"
+# Logging-Level (error, warn, info, debug)
+verbose = "warn"


### PR DESCRIPTION
This pull request contains several minor improvements and cleanups to documentation, spell-check configuration, and markdown checking scripts. The main focus is on improving the developer experience by clarifying documentation, refining script outputs, and updating custom word lists for spell checking.

**Documentation and Developer Workflow Improvements:**

* Improved `CONTRIBUTING.md` by adding a direct link to the "Contributing to ZETA" section, clarifying code block formatting (now using `yaml` for examples), and removing unnecessary blank lines for better readability. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R10) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L66-R67) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L109-R108) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L132-R139) [[5]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L77-L78)
* Minor formatting corrections in `docs/user-manual/Anleitungen/ZETA_Guard_Quickstart.md` for consistency in configuration and directive lists. [[1]](diffhunk://#diff-017598842dd72a938247aac3507b95209a9eb623b5a5e92af7e0aaaa53b15129L212-R212) [[2]](diffhunk://#diff-017598842dd72a938247aac3507b95209a9eb623b5a5e92af7e0aaaa53b15129L319-R324)

**Spell-Checking and Custom Word List Updates:**

* Added new domain-specific terms (`ANFTI`, `kubeconform`, `kubeval`) to `.cspell/zeta-words.txt` to reduce false positives in spell checks. [[1]](diffhunk://#diff-179463832ae8a37cf1d26debdc97cccb329a679b4410401425f79bc0aeae6483R82) [[2]](diffhunk://#diff-179463832ae8a37cf1d26debdc97cccb329a679b4410401425f79bc0aeae6483R91-R92)

**Script and Tooling Enhancements:**

* Enhanced `scripts/check-markdown.sh` by improving log messages, suppressing unnecessary output from tools, and providing clearer error reporting for link checks, markdown linting, and spell checking. Also, warnings for missing tools are now more concise. [[1]](diffhunk://#diff-2439b2054955d494b6c25ef67623cdb13043f12ebf9ab26af6216eeb557aaf41L65-R69) [[2]](diffhunk://#diff-2439b2054955d494b6c25ef67623cdb13043f12ebf9ab26af6216eeb557aaf41L91-R91) [[3]](diffhunk://#diff-2439b2054955d494b6c25ef67623cdb13043f12ebf9ab26af6216eeb557aaf41L121-R147)
* Updated `scripts/lychee.toml` to reduce log verbosity for link checking, making script output less noisy by setting the logging level to `warn`.