### PR TITLE
fix: update response schema references to dcr-response-202.yaml

### DIFF
--- a/docs/api/v1/index.md
+++ b/docs/api/v1/index.md
@@ -348,7 +348,7 @@ Content-Type: application/json
 ##### 4.1.4.2 Dynamic Client Registration Response
 
 **Antwort-Beispiel (202 Accepted):**
-*Response-Schema:* [register-response-202.yaml](../../../src/schemas/register-response-202.yaml)
+*Response-Schema:* [dcr-response-202.yaml](../../../src/schemas/dcr-response-202.yaml)
 
 ```http
 HTTP/1.1 202 Accepted

--- a/tmp/_zeta_5_3_extract.txt
+++ b/tmp/_zeta_5_3_extract.txt
@@ -947,7 +947,7 @@ Version: 1.3.0 © gematik - öffentlich Stand: 17.04.2026
 Registrierungsdaten werden unter dieser ID in einem temporären Cache zwischengespeichert.
 (12): Das OTP wird Out-of-Band (per E-Mail) an den Nutzer gesendet.
 (13): Der AuthS antwortet dem Client mit einem 202 Accepted, der transaction_id und der Aufforderung, das OTP
-einzugeben (siehe Schema [register-response-202.yaml]).
+einzugeben (siehe Schema [dcr-response-202.yaml]).
 (14 - 15): Der Nutzer tippt das OTP in die App ein. Die App sendet einen POST /register/verify Request, der die
 transaction_id und den code enthält (siehe [verify-request.yaml]).
 (16): Der Server verifiziert den Code gegen den Cache.


### PR DESCRIPTION
This pull request updates the naming of a response schema file in both the API documentation and related descriptive text to improve consistency and clarity. The main change is renaming references from `register-response-202.yaml` to `dcr-response-202.yaml`.

**Documentation updates:**

* Changed the response schema reference in the API documentation from `register-response-202.yaml` to `dcr-response-202.yaml` in `docs/api/v1/index.md` to reflect the new naming convention.
* Updated the descriptive text in `tmp/_zeta_5_3_extract.txt` to reference `dcr-response-202.yaml` instead of `register-response-202.yaml` for consistency.