### PR TITLE
fix: Correct definition name for AppleAttestationToken in ZETA Guard …

### DIFF
--- a/src/schemas/zeta-attestation-token.yaml
+++ b/src/schemas/zeta-attestation-token.yaml
@@ -108,7 +108,7 @@ definitions:
               quote_verified: 
                 type: boolean
 
-  jk:
+  AppleAttestationToken:
     type: object
     allOf:
       - $ref: "#/definitions/BaseTokenProperties"


### PR DESCRIPTION
This pull request updates the schema definitions in `src/schemas/zeta-attestation-token.yaml` by renaming the `jk` definition to `AppleAttestationToken` for improved clarity.

Schema definition update:

* Renamed the `jk` definition to `AppleAttestationToken` to provide a more descriptive and accurate name.…attestation token schema